### PR TITLE
Modify helm upgrade command for gloo-platform-crds

### DIFF
--- a/README.md
+++ b/README.md
@@ -584,7 +584,8 @@ Cluster1 will act as the management cluster and workload cluster: (see [mgmt-val
 helm repo add gloo-platform https://storage.googleapis.com/gloo-platform/helm-charts
 helm repo update
 
-helm upgrade -i gloo-platform-crds gloo-platform/gloo-platform-crds -n gloo-mesh --create-namespace --version=2.10.1 --kube-context=$CLUSTER1
+helm upgrade -i gloo-platform-crds gloo-platform/gloo-platform-crds -n gloo-mesh --create-namespace --version=2.10.1 \
+  --set installEnterpriseCrds=false --kube-context=$CLUSTER1
 helm upgrade -i gloo-platform gloo-platform/gloo-platform -n gloo-mesh --version 2.10.1 --kube-context=$CLUSTER1 --values mgmt-values.yaml \
   --set licensing.glooMeshLicenseKey=$GLOO_MESH_LICENSE_KEY
 ```


### PR DESCRIPTION
Updated helm upgrade command to include installEnterpriseCrds flag. Not having this causes UI to trigger `BP0005` insight 